### PR TITLE
Track page views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Autometrics Docs
+
+## Note on Page Metrics
+
+We use Segment for keeping track of page views. From there we forward to Google Tag Manager, which forwards to Google Analytics.
+
+Next is a little particular when it comes to analytics. See the following files for how we went about implementing (e.g.) page view analytics:
+
+- `src/pages/_app.js` - Load the segment snippet
+-
+
+To test analytics locally, create `.env` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We use Segment for keeping track of page views. From there we forward to Google 
 
 Next is a little particular when it comes to analytics. See the following files for how we went about implementing (e.g.) page view analytics:
 
-- `src/pages/_app.js` - Load the segment snippet
+- `src/pages/_app.jsx` - Load the segment snippet
 -
 
-To test analytics locally, create `.env` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable
+To test analytics locally, create `.env.local` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Autometrics Docs
 
-## Note on Page View Analytics
+Uses Nextra to generate a static site from markdown files.
 
-We use Segment for keeping track of page views. From there we forward to Google Tag Manager, which forwards to Google Analytics.
-
-Next (and by extension, Nextra) is a little particular when it comes to analytics. See the `src/pages/_app.jsx` file for how we went about implementing (e.g.) page view analytics.
-
-To test analytics locally, create `.env.local` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable (you can find this in Segment).
+The `_app.jsx` file contains some application setup logic.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Autometrics Docs
 
-## Note on Page Metrics
+## Note on Page View Analytics
 
 We use Segment for keeping track of page views. From there we forward to Google Tag Manager, which forwards to Google Analytics.
 
-Next is a little particular when it comes to analytics. See the following files for how we went about implementing (e.g.) page view analytics:
+Next (and by extension, Nextra) is a little particular when it comes to analytics. See the `src/pages/_app.jsx` file for how we went about implementing (e.g.) page view analytics.
 
-- `src/pages/_app.jsx` - Load the segment snippet
--
-
-To test analytics locally, create `.env.local` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable
+To test analytics locally, create `.env.local` and add a `NEXT_PUBLIC_SEGMENT_WRITE_KEY` variable (you can find this in Segment).

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
+		"@segment/snippet": "^4.16.0",
 		"next": "^13.0.6",
 		"nextra": "latest",
 		"nextra-theme-docs": "latest",

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -4,7 +4,6 @@ import * as snippet from "@segment/snippet";
 
 export default function Nextra({ Component, pageProps }) {
   const loadSegment = () => {
-    console.log("loading segment");
     const options = {
       apiKey: process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY,
     };
@@ -16,10 +15,16 @@ export default function Nextra({ Component, pageProps }) {
   };
 
   useEffect(() => {
-    if (window && window.analytics) {
-      window.analytics.page("Testing 123");
-      // console.log("analytics loaded");
-    } else {
+    if (window && window.analytics)
+      // NOTE - This will track virtual page views when transitioning client side,
+      //        but we lack descriptive page names.
+      //        To add page names, we can either set a `pageName` prop on the Components themselves,
+      //        or make use of getStaticProps in all of the pages to set the page name on page Props, then pass it to the function here
+      //        See the following:
+      //          - https://javascript.plainenglish.io/add-segment-google-analytics-to-your-typescript-next-js-app-af9fc7cd83a9
+      //          - https://morganfeeney.com/guides/how-to-integrate-google-tag-manager-with-nextjs
+      window.analytics.page(null);
+    else {
       // console.log("analytics not loaded");
     }
   }, []);

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,0 +1,38 @@
+import Script from "next/script";
+import { useEffect } from "react";
+import * as snippet from "@segment/snippet";
+
+export default function Nextra({ Component, pageProps }) {
+  const loadSegment = () => {
+    console.log("loading segment");
+    const options = {
+      apiKey: process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY,
+    };
+    if (process.env.NEXT_PUBLIC_NODE_ENV) {
+      return snippet.max(options);
+    } else {
+      return snippet.min(options);
+    }
+  };
+
+  useEffect(() => {
+    if (window && window.analytics) {
+      window.analytics.page("Testing 123");
+      // console.log("analytics loaded");
+    } else {
+      // console.log("analytics not loaded");
+    }
+  }, []);
+
+  return (
+    <>
+      <Script
+        id="segmentScript"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: loadSegment() }}
+      />
+
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -11,13 +11,13 @@ Autometrics is built on the excellent Prometheus and OpenTelemetry open source p
 ### Demo
 
 <p>
-	<video
-		controls
-		loop
-		muted
-		src="https://user-images.githubusercontent.com/3262610/220152261-2ad6ab2b-f951-4b51-8d6e-855fb71440a3.mp4"
-		alt="Autometrics demo video"
-	></video>
+  <video
+    controls
+    loop
+    muted
+    src="https://user-images.githubusercontent.com/3262610/220152261-2ad6ab2b-f951-4b51-8d6e-855fb71440a3.mp4"
+    alt="Autometrics demo video"
+  ></video>
 </p>
 
 ### Getting started

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,6 +182,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ndhoule/each@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/each@npm:2.0.1"
+  dependencies:
+    "@ndhoule/keys": ^2.0.0
+  checksum: f2aa44fb4248b2939b038c6cdbfb442f29cebb181f6058081b9af402c8c6e1e82a26fd9d89c2a2fc72be98b934902ecdf260bcfff171fa48aea4261a26a0e0c7
+  languageName: node
+  linkType: hard
+
+"@ndhoule/keys@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@ndhoule/keys@npm:2.0.0"
+  checksum: f77be060eb706a072e9c41d8939dcbd7bf27ead2f113a75fd9718b3c6a623540f324f7200e474418feb6277f1b99952b67667129bd66a39fdf93531980066488
+  languageName: node
+  linkType: hard
+
+"@ndhoule/map@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/map@npm:2.0.1"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+  checksum: b3bffd71babe9b9cdb882bd89d7785bb36d6063d44757aa7ed726a15a5d3c2ecb5198dbcda43a63d4585b4dfed96e2bd75b7b54bc1b5e44c58945118a2304d5c
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:13.4.1":
   version: 13.4.1
   resolution: "@next/env@npm:13.4.1"
@@ -298,6 +323,15 @@ __metadata:
   version: 12.0.0
   resolution: "@rometools/cli-win32-x64@npm:12.0.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@segment/snippet@npm:^4.16.0":
+  version: 4.16.0
+  resolution: "@segment/snippet@npm:4.16.0"
+  dependencies:
+    "@ndhoule/map": ^2.0.1
+  checksum: d73a7ddadbd7e983330a2a29de34cba85811037deb040374579d053030caf0da04b9a80b9aa3eaf600d0d465e7e8750d8c8edee9b0d3184f1e0ccf306590c7b1
   languageName: node
   linkType: hard
 
@@ -524,6 +558,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "autometrics-docs@workspace:."
   dependencies:
+    "@segment/snippet": ^4.16.0
     "@types/node": 18.11.10
     "@types/react": 18.2.0
     next: ^13.0.6


### PR DESCRIPTION
## Notes

- Fires page view events to Segment
- Loads Segment via a script tag in `_app.jsx`
- Update README with info on the analytics setup

## Improvements (for the future)

- Implement descriptive page names for each component
- Document our production analytics setup in Notion

## Important!

When deploying to prod:

- [ ] Add env var: `NEXT_PUBLIC_SEGMENT_WRITE_KEY`, use the segment write key for the Autometrics Docs site
- [ ] Make sure we have a `NEXT_PUBLIC_NODE_ENV` env var set in production