### PR TITLE
Add configuration and wrapper explainers

### DIFF
--- a/src/pages/typescript/_meta.json
+++ b/src/pages/typescript/_meta.json
@@ -1,7 +1,9 @@
 {
   "quickstart": "Quickstart",
+	"using-wrappers-and-decorators": "Using wrappers and decorators",
   "adding-version-information": "Adding version information",
 	"adding-alerts-and-slos": "Adding alerts and SLOs",
+	"configuration": "Configuration",
   "reference": {
     "title": "API Reference ↗",
     "href": "https://github.com/autometrics-dev/autometrics-ts/tree/main/packages/lib/reference",

--- a/src/pages/typescript/configuration.mdx
+++ b/src/pages/typescript/configuration.mdx
@@ -6,7 +6,7 @@ By default, Autometrics exposes your metrics with OpenTelemetry's Prometheus
 Exporter on port `:9464`, using the endpoint `/metrics`. You can configure it as
 you wish, however, by using the `init` function.
 
-Here is an example that sets the exporter to use port 7777:
+Here is an example that sets the exporter to use port `7777`:
 
 ```javascript
 import { autometrics, init } from "@autometrics/autometrics";

--- a/src/pages/typescript/configuration.mdx
+++ b/src/pages/typescript/configuration.mdx
@@ -1,0 +1,29 @@
+## Configuration
+
+### Set your own Exporter
+
+By default, Autometrics exposes your metrics with OpenTelemetry's Prometheus
+Exporter on port `:9464`, using the endpoint `/metrics`. You can configure it as
+you wish, however, by using the `init` function.
+
+Here is an example that sets the exporter to use port 7777:
+
+```javascript
+import { autometrics, init } from "@autometrics/autometrics";
+import { PrometheusExporter } from "@opentelemetry/exporter-prometheus";
+
+const exporter = new PrometheusExporter({ port: 7777 });
+init({ exporter });
+```
+
+### Language service plugin
+
+The language service plugin can be configured in the `tsconfig.json` file.
+
+#### Options
+
+| key             | description                                                     |
+| --------------- | --------------------------------------------------------------- |
+| `name`          | always `@autometrics/typescript-plugin`                         |
+| `prometheusUrl` | sets the base URL for PromQL queries. Default: `localhost:9090` |
+

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -1,0 +1,112 @@
+
+# Using wrappers and decorators in
+
+## Node.js
+
+Use Autometrics wrappers to instrument the functions you want to track (e.g.:
+request handlers or database calls).
+
+### Wrapping plain-old functions
+
+Wrappers are simple functions that wrap the original function declaration and
+instrument it with metrics. They allow the language service plugin to add
+additional information in the type docs.
+
+Use function wrappers to wrap request handlers, database calls, or other
+pieces of important business logic that you want to measure.
+
+> **Note**: Wrapped functions must be named. Autometrics will throw an error if
+> it can't access the name of the function.
+
+Example:
+
+```typescript
+import { autometrics } from "autometrics";
+
+const createUserWithMetrics = autometrics(async function createUser(payload: User) {
+  // ...
+});
+
+createUserWithMetrics();
+```
+
+### Decorating class methods
+
+When using a decorator for a class method, it is wrapped in additional code that
+instruments the method with OpenTelemetry metrics.
+
+Here's a snippet from a NestJS example project that uses Autometrics:
+
+```typescript
+import { Controller, Get } from "@nestjs/common";
+import { AppService } from "./app.service";
+import { Autometrics } from "autometrics";
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  @Autometrics()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}
+```
+
+Alternatively, you can apply the same decorator to the entire class and
+instrument all of its methods:
+
+```typescript
+// ...
+@Autometrics()
+export class AppController {
+  // ...
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}
+```
+
+## Browser (Experimental)
+
+> **Note**
+> Support for client-side use of the Autometrics library is still very early and
+> experimental.
+
+### Set up the push gateway
+
+In order for Prometheus to succesfully get your client-side app metrics, you
+will need to push them to an aggregating push gateway [like this
+one](https://github.com/zapier/prom-aggregation-gateway).
+
+Use the `init` function to configure the gateway URL that Autometrics should
+push the data to. You can also set the push interval with the `pushInterval`
+property (default is every 5000 miliseconds);
+
+```typescript
+init({ pushGateway: "<link_to_gateway>" });
+```
+
+### Use Autometrics wrapper with options
+
+The same wrapper functions can be used in browser environments. Note that
+bundlers often change the names of functions and modules in production, which
+can impact the library.
+
+To get around this issue, wrappers accept an options object as
+their first argument, which explicitly assigns a function and module name.
+
+```typescript
+const myFunction = autometrics(
+  {
+    functionName: "myFunction",
+    moduleName: "Module",
+  },
+  async () => {
+    // ... myFunction body
+  }
+);
+```
+

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -11,12 +11,9 @@ request handlers or database calls).
 
 ### Wrapping plain-old functions
 
-Wrappers are simple functions that wrap the original function declaration and
-instrument it with metrics. They also enable the language service plugin to add
-additional information in the type docs.
+Wrappers are simple functions that wrap the original function declaration and instrument it with metrics. They also enable the language service plugin to add additional information in the type docs and the VSCode extension to link to the graphs.
 
-Use function wrappers to wrap request handlers, database calls, or other
-pieces of important business logic that you want to measure.
+Use function wrappers to wrap request handlers, database calls, or other pieces of important business logic that you want to measure.
 
 <Callout type="info">
     Wrapped functions must be named. Anonymous (arrow) functions will not be instrumented.
@@ -36,8 +33,7 @@ createUserWithMetrics();
 
 ### Decorating class methods
 
-When using a decorator for a class method, it is wrapped in additional code that
-instruments the method with metrics.
+When using a decorator for a class method, it is wrapped in additional code that instruments the method with metrics.
 
 Here's a snippet from a NestJS example project that uses Autometrics:
 
@@ -76,8 +72,7 @@ export class AppController {
 ## Browser (Experimental)
 
 <Callout type="warning">
-    Support for client-side use of the Autometrics library is still very early and
-    experimental. Things are likely to break in unexpected places.
+    Support for client-side use of the Autometrics library is still very early and experimental. Things are likely to break in unexpected places.
 </Callout>
 
 ### Set up the push gateway

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -1,9 +1,12 @@
+import { Callout } from "nextra-theme-docs"
 
-# Using wrappers and decorators in
+# Using wrappers and decorators
 
 ## Node.js
 
-Use Autometrics wrappers to instrument the functions you want to track (e.g.:
+Use the Autometrics wrappers and decorators to instrument the functions you want
+to track. Usually it makes sense to wrap functions that are doing some business
+logic, making network calls, or are otherwise critical to the service (e.g.:
 request handlers or database calls).
 
 ### Wrapping plain-old functions
@@ -15,8 +18,10 @@ additional information in the type docs.
 Use function wrappers to wrap request handlers, database calls, or other
 pieces of important business logic that you want to measure.
 
-> **Note**: Wrapped functions must be named. Autometrics will throw an error if
-> it can't access the name of the function.
+<Callout type="info">
+    Wrapped functions must be named. Autometrics will, not affect the wrapped
+    function but will log an error if it can't access the name of the function.
+</Callout>
 
 Example:
 
@@ -71,9 +76,10 @@ export class AppController {
 
 ## Browser (Experimental)
 
-> **Note**
-> Support for client-side use of the Autometrics library is still very early and
-> experimental.
+<Callout type="warning">
+    Support for client-side use of the Autometrics library is still very early and
+    experimental. Things are likely to break in unexpected places.
+</Callout>
 
 ### Set up the push gateway
 

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -72,7 +72,7 @@ export class AppController {
 ## Browser (Experimental)
 
 <Callout type="warning">
-    Support for client-side use of the Autometrics library is still very early and experimental. Things are likely to break in unexpected places.
+    Support for client-side use of the Autometrics library is limited and experimental. Things are likely to break in unexpected places.
 </Callout>
 
 ### Set up the push gateway
@@ -91,12 +91,9 @@ init({ pushGateway: "<link_to_gateway>" });
 
 ### Use Autometrics wrapper with options
 
-The same wrapper functions can be used in browser environments. Note that
-bundlers often change the names of functions and modules in production, which
-can impact the library.
+The same wrapper functions can be used in browser environments. Note that bundlers minify code and obfuscate the names of functions and modules in production.
 
-To get around this issue, wrappers accept an options object as
-their first argument, which explicitly assigns a function and module name.
+To get around this issue, wrappers accept an options object as their first argument, which explicitly assigns a function and module name.
 
 ```typescript
 const myFunction = autometrics(

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -19,8 +19,7 @@ Use function wrappers to wrap request handlers, database calls, or other
 pieces of important business logic that you want to measure.
 
 <Callout type="info">
-    Wrapped functions must be named. Autometrics will, not affect the wrapped
-    function but will log an error if it can't access the name of the function.
+    Wrapped functions must be named. Anonymous (arrow) functions will not be instrumented.
 </Callout>
 
 Example:

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -9,7 +9,7 @@ to track. Usually it makes sense to wrap functions that are doing some business
 logic, making network calls, or are otherwise critical to the service (e.g.:
 request handlers or database calls).
 
-### Wrapping plain-old functions
+### Wrapping plain old functions
 
 Wrappers are simple functions that wrap the original function declaration and instrument it with metrics. They also enable the language service plugin to add additional information in the type docs and the VSCode extension to link to the graphs.
 

--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -12,7 +12,7 @@ request handlers or database calls).
 ### Wrapping plain-old functions
 
 Wrappers are simple functions that wrap the original function declaration and
-instrument it with metrics. They allow the language service plugin to add
+instrument it with metrics. They also enable the language service plugin to add
 additional information in the type docs.
 
 Use function wrappers to wrap request handlers, database calls, or other
@@ -38,7 +38,7 @@ createUserWithMetrics();
 ### Decorating class methods
 
 When using a decorator for a class method, it is wrapped in additional code that
-instruments the method with OpenTelemetry metrics.
+instruments the method with metrics.
 
 Here's a snippet from a NestJS example project that uses Autometrics:
 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -19,6 +19,18 @@ const config: DocsThemeConfig = {
       titleTemplate: "%s | Autometrics",
     };
   },
+  head: (
+    <>
+      <meta
+        property="og:title"
+        content="Autometrics - Developer-first Observability Framework"
+      />
+      <meta
+        property="og:description"
+        content="Autometrics is a developer-first observability framework for understanding the error rate, response time, and  production usage of any function in your code. Implemented in Rust, Typescript, Golang and Python. Built on Open Telemetry and Prometheus."
+      />
+    </>
+  ),
   primaryHue: 240,
   docsRepositoryBase: "https://github.com/autometrics-dev/docs",
   sidebar: {

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -6,7 +6,7 @@ const config: DocsThemeConfig = {
   logo: <Logo />,
   darkMode: false,
   nextThemes: {
-    forcedTheme: "light"
+    forcedTheme: "light",
   },
   project: {
     link: "https://github.com/autometrics-dev",
@@ -23,6 +23,7 @@ const config: DocsThemeConfig = {
   docsRepositoryBase: "https://github.com/autometrics-dev/docs",
   sidebar: {
     toggleButton: true,
+    defaultMenuCollapseLevel: 1,
   },
   footer: {
     text: (


### PR DESCRIPTION
This PR moves the expanded documentation about the TypeScript library to the guides section here. It also updates the sidebar default expansion level.

- set default menu collapse to 1
- add the right side bar config
- add configuration docs
- add wrapper docs
