### PR TITLE
Add brew instructions for macOS

### DIFF
--- a/src/pages/local-development.mdx
+++ b/src/pages/local-development.mdx
@@ -39,11 +39,8 @@ You can install the CLI using Homebrew or by downloading the binary directly.
 
 <Tabs items={["macOS", "Linux"]}>
     <Tab>
-        ```shell filename="ARM (M-series chips)"
-        curl https://github.com/autometrics-dev/am/releases/latest/download/am-macos-aarch64
-        ```
-        ```shell filename="x86_64"
-        curl https://github.com/autometrics-dev/am/releases/latest/download/am-macos-x86_64
+        ```shell filename="shell"
+        brew install autometrics-dev/tap/am
         ```
     </Tab>
     <Tab>


### PR DESCRIPTION
This update adds proper `brew install` instructions for macOS now that the install works