### PR TITLE
Better cover pages for "deploying" sections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @keturiosakys @Nlea @mies

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @keturiosakys @Nlea @mies
+* @keturiosakys @Nlea

--- a/src/components/DeployingPrometheus.tsx
+++ b/src/components/DeployingPrometheus.tsx
@@ -2,7 +2,7 @@ import { getPagesUnderRoute } from "nextra/context";
 import { Cards, Card } from "nextra-theme-docs";
 import { MdxFile } from "nextra";
 
-export default function ConfiguringPrometheus() {
+export default function DeployingPrometheus() {
   const pages = getPagesUnderRoute("/deploying-prometheus").filter((page) => {
     return (
       page.kind === "MdxPage" && page.route !== "/deploying-prometheus/local"
@@ -17,7 +17,7 @@ export default function ConfiguringPrometheus() {
           <Card
             children
             icon
-            title={page.frontMatter?.short}
+            title={page.frontMatter?.title}
             href={page.route}
           />
         );

--- a/src/pages/deploying-explorer.mdx
+++ b/src/pages/deploying-explorer.mdx
@@ -1,0 +1,22 @@
+import { Cards, Card } from "nextra-theme-docs"
+
+# Deploying Explorer
+
+Explorer is a special Autometrics-specific interface for Prometheus data. It is a simple client-based application that connects to a running Prometheus instance. Once connected it automatically recognizes Autometrics-labeled metrics and visualizes them in a simple and easy to use interface.
+
+## Running Explorer locally
+
+Explorer runs on top of the `am` CLI - simply download, install, and run the CLI and Explorer will be available at `http://localhost:8080`.
+
+See [Local Development](/docs/local-development) for more information.
+
+## Deploying Explorer
+
+The `am` CLI can be run as a simple service app and is available as a Docker image. See guides below for platform-specific instructions.
+
+<Cards num={1}>
+	<Card
+	children icon title = "Deploying Explorer with Docker" href="/deploying-explorer/docker"/>
+	<Card
+	children icon title = "Deploying Explorer on Railway" href="/deploying-explorer/railway"/>
+</Cards>

--- a/src/pages/deploying-prometheus.mdx
+++ b/src/pages/deploying-prometheus.mdx
@@ -1,13 +1,15 @@
-import ConfiguringPrometheus from "@/components/ConfiguringPrometheus.tsx";
+import DeployingPrometheus from "@/components/DeployingPrometheus.tsx";
 import { Cards, Card } from "nextra-theme-docs"
 
-# Configuring Prometheus
+# Deploying Prometheus
 
-To see your Autometrics-instrumented metrics, you'll need to run [Prometheus](https://prometheus.io). Prometheus is pull-based, meaning it will poll your app on an endpoint you specify to sample the metrics.
+Autometrics is built on top of [Prometheus](https://prometheus.io) - a popular open source timeseries database and alerting system.
+
+To see the metrics your instrumented app generates you will need to deploy a Prometheus instance alongside it. Prometheus is pull-based, meaning that once deployed it will poll your app on an endpoint you specify to sample the metrics.
 
 ## Prometheus locally
 
-Here's how you can setup Prometheus locally:
+To get started and understand how Prometheus works you can run it locally:
 
 <Cards num={1}>
 	<Card
@@ -28,4 +30,4 @@ Here's how you can setup Prometheus locally:
 
 If you've already tried out Autometrics with Prometheus locally and want to set it up in production, see instructions below for specific deploy targets.
 
-<ConfiguringPrometheus />
+<DeployingPrometheus />


### PR DESCRIPTION
This is a batch of smaller updates, renames and improvements to the cover pages of the "Deploying X" pages

- update vercel and move rome to biome
- add codeowners
- rename Configuring -> Deploying component
- add better cover pages
