### PR TITLE
Update documentation following autometrics-go 0.7

### DIFF
--- a/src/pages/go/adding-version-information.mdx
+++ b/src/pages/go/adding-version-information.mdx
@@ -24,7 +24,8 @@ autometrics.Init(
         Version: "<version_here>",
         Commit:  "<git_commit_hash_here",
         Branch:  "<git_branch_here>",
-    }
+    },
+    nil,
 )
 ```
 
@@ -54,7 +55,8 @@ autometrics.Init(
         Version: Version,
         Commit:  Commit,
         Branch:  Branch,
-    }
+    },
+    nil,
 )
 ```
 

--- a/src/pages/go/quickstart.mdx
+++ b/src/pages/go/quickstart.mdx
@@ -36,7 +36,7 @@ In the main entrypoint of your program, add the package:
 
 ```go filename="main.go"
 import (
-	autometrics "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+	autometrics "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
 )
 ```
 
@@ -46,7 +46,8 @@ And then in your main function initialize the metrics:
 	autometrics.Init(
 		nil,
 		autometrics.DefBuckets,
-		autometrics.BuildInfo{}
+		autometrics.BuildInfo{},
+                nil,
 	)
 ```
 
@@ -87,15 +88,20 @@ The generator will augment your doc comment to add quick links to metrics (using
 
 The environment variable `AM_PROMETHEUS_URL` controls the base URL of the instance that is scraping the deployed version of your code. Having an environment variable means you can change the generated links without touching your code. Default value: `http://localhost:9090/`.
 
+<Callout>
+If you do not want to have lengthy documentation generated on top of the function, you can use `//autometrics:inst` annotation instead of `//autometrics:doc`.
+</Callout>
+
 ### Make metrics available to Prometheus
 
 The last step now is to actually expose the generated metrics to the Prometheus instance.
 
-For Prometheus the shortest way is to add the handler code in your main entrypoint:
+For Prometheus the shortest way is to add the handler code in your main entrypoint (this
+example also shows the `Init` call when choosing to use OpenTelemetry to handle metrics):
 
 ```go {12} filename="main.go"
 import (
-	autometrics "github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel"
+	autometrics "github.com/autometrics-dev/autometrics-go/otel/autometrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -103,7 +109,8 @@ func main() {
 	autometrics.Init(
 		"web-server",
 		autometrics.DefBuckets,
-		autometrics.BuildInfo{}
+		autometrics.BuildInfo{},
+                nil,
 	)
 	http.Handle("/metrics", promhttp.Handler())
 }


### PR DESCRIPTION
The version in the PR is _not_ a typo, an extra PR is already necessary to tackle the
changes that 0.8 brought as well, mostly:

- The ability to push metrics using the `PushConfiguration` argument in `Init`, and
- The extra utility around `BuildInfo`, with the service name and a [ULID](https://github.com/oklog/ulid)
 (by default) as the instance ID to help debugging in the case of horizontally scaled services.