### PR TITLE
Fix incorrect import path in docs

### DIFF
--- a/src/pages/typescript/using-wrappers-and-decorators.mdx
+++ b/src/pages/typescript/using-wrappers-and-decorators.mdx
@@ -22,7 +22,8 @@ Use function wrappers to wrap request handlers, database calls, or other pieces 
 Example:
 
 ```typescript
-import { autometrics } from "autometrics";
+import { Autometrics } from '@autometrics/autometrics';
+
 
 const createUserWithMetrics = autometrics(async function createUser(payload: User) {
   // ...
@@ -40,7 +41,8 @@ Here's a snippet from a NestJS example project that uses Autometrics:
 ```typescript
 import { Controller, Get } from "@nestjs/common";
 import { AppService } from "./app.service";
-import { Autometrics } from "autometrics";
+import { Autometrics } from '@autometrics/autometrics';
+
 
 @Controller()
 export class AppController {


### PR DESCRIPTION
Fix incorrect import path in docs

I noticed when running this myself I needed to import from: 

``` typescript
import { Autometrics } from "autometrics";
```

