### PR TITLE
Add Northflank's homepage URL

### DIFF
--- a/src/pages/deploying-explorer/northflank.mdx
+++ b/src/pages/deploying-explorer/northflank.mdx
@@ -6,7 +6,7 @@ import { Steps } from "nextra/components";
 
 # Deploying Explorer on Northflank
 
-Explorer can be deployed as a Northflank service using the `autometrics/am-proxy` Docker image. [Northflank supports running images from a container registery](https://northflank.com/docs/v1/application/run/run-an-image-from-a-container-registry). If no container registery is provided Northflank will default to Dockerhub.
+Explorer can be deployed as a [Northflank](https://northflank.com/) service using the `autometrics/am-proxy` Docker image. [Northflank supports running images from a container registery](https://northflank.com/docs/v1/application/run/run-an-image-from-a-container-registry). If no container registery is provided Northflank will default to Dockerhub.
 
 ![A screenshot to create a new service with an external Docker image](/images/northflank_docker_image.png)
 

--- a/src/pages/deploying-prometheus/northflank.mdx
+++ b/src/pages/deploying-prometheus/northflank.mdx
@@ -44,7 +44,7 @@ USER root
 
 ### Create a Northflank service from a GitHub repo
 
-Create a Northflank service from our newly created GitHub repo, it should pick up the configuration from the Dockerfile 
+Create a [Northflank](https://northflank.com/) service from our newly created GitHub repo, it should pick up the configuration from the Dockerfile 
 
 ### Add Network configurations
 


### PR DESCRIPTION
Add Northflank's homepage in the first mention of the deployment guides for Prometheus and Explorer